### PR TITLE
Fix "Cannot assign to read only property 'drain' of object" error

### DIFF
--- a/lib/nikobus/TaskQueue.js
+++ b/lib/nikobus/TaskQueue.js
@@ -18,7 +18,8 @@ function TaskQueue(log, concurrency)
 			);
 		}.bind(this), concurrency
 	);
-	this.queue.drain = function(){};
+	/* this.queue.drain = function(){}; */
+        this.queue.drain(async () => {});
 }
 
 TaskQueue.prototype.push = function(name, args, callback)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "homebridge": ">=0.4.6"
   },
   "dependencies": {
-    "serialport": "latest",
+    "serialport": "9.2.4",
     "async": "3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "homebridge": ">=0.4.6"
   },
   "dependencies": {
-    "serialport": "7.1.5",
+    "serialport": "latest",
     "async": "2.6.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "serialport": "latest",
-    "async": "2.6.3"
+    "async": "3.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/timschuerewegen/homebridge-nikobus.git"
+    "url": "git://github.com/hauserbauten/homebridge-nikobus.git"
   },
   "bugs": {
     "url": "https://github.com/timschuerewegen/homebridge-nikobus/issues"


### PR DESCRIPTION
I experienced a runtime error using the latest async library (TypeError: Cannot assign to read only property 'drain' of object '#<Object>')
I solved it thanks to that article : https://stackoverflow.com/questions/63885444/nodejs-async-queue-typeerror-cannot-assign-to-read-only-property-drain-of-ob